### PR TITLE
feat/resort-card-with-sorting-menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,12 @@
         "next": "15.0.3",
         "next-themes": "^0.4.3",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-icons": "^5.3.0"
       },
       "devDependencies": {
+        "@emotion/react": "^11.13.3",
+        "@emotion/styled": "^11.13.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.0.1",
         "@testing-library/user-event": "^14.5.2",
@@ -504,7 +507,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.12.0.tgz",
       "integrity": "sha512-y2WQb+oP8Jqvvclh8Q55gLUyb7UFvgv7eJfsj7td5TToBrIUtPay2kMrZi4xjq9qw2vD0ZR5fSho0yqoFgX7Rw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.16.7",
         "@babel/runtime": "^7.18.3",
@@ -524,7 +526,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.13.1.tgz",
       "integrity": "sha512-iqouYkuEblRcXmylXIwwOodiEK5Ifl7JcX7o6V4jI3iW4mLXX3dmt5xwBtIkJiQEXFAI+pC8X0i67yiPkH9Ucw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.9.0",
         "@emotion/sheet": "^1.4.0",
@@ -559,7 +560,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.13.3.tgz",
       "integrity": "sha512-lIsdU6JNrmYfJ5EbUCf4xW1ovy5wKQ2CkPRM4xogziOxH1nXxBSjpC9YqbFAP7circxMfYp+6x676BqWcEiixg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.12.0",
@@ -596,8 +596,31 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
       "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/styled": {
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.13.0.tgz",
+      "integrity": "sha512-tkzkY7nQhW/zC4hztlwucpT8QEZ6eUzpXDRhww/Eej4tFfO0FxQYWRyg/c5CCXa4d/f174kqeXYjuQRnhzf6dA==",
+      "dev": true,
       "license": "MIT",
-      "peer": true
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.12.0",
+        "@emotion/is-prop-valid": "^1.3.0",
+        "@emotion/serialize": "^1.3.0",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.1.0",
+        "@emotion/utils": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0-rc.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@emotion/unitless": {
       "version": "0.10.0",
@@ -624,8 +647,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
       "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -2386,8 +2408,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/statuses": {
       "version": "2.0.5",
@@ -4014,7 +4035,6 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
       "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "cosmiconfig": "^7.0.0",
@@ -4327,8 +4347,7 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -4347,7 +4366,6 @@
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
       "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
@@ -4650,7 +4668,6 @@
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
@@ -4659,8 +4676,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/es-abstract": {
       "version": "1.23.3",
@@ -5480,8 +5496,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
       "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -5897,7 +5912,6 @@
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "react-is": "^16.7.0"
       }
@@ -6582,8 +6596,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -6685,8 +6698,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -7248,7 +7260,6 @@
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -7325,7 +7336,6 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7560,6 +7570,15 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
+      "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {
@@ -8042,7 +8061,6 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8306,8 +8324,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
       "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -9181,7 +9198,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">= 6"
       }

--- a/package.json
+++ b/package.json
@@ -16,9 +16,12 @@
     "next": "15.0.3",
     "next-themes": "^0.4.3",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-icons": "^5.3.0"
   },
   "devDependencies": {
+    "@emotion/react": "^11.13.3",
+    "@emotion/styled": "^11.13.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.0.1",
     "@testing-library/user-event": "^14.5.2",

--- a/setup.js
+++ b/setup.js
@@ -1,0 +1,15 @@
+beforeEach(() => {
+	Object.defineProperty(window, 'matchMedia', {
+		writable: true,
+		value: jest.fn().mockImplementation((query) => ({
+			matches: false,
+			media: query,
+			onchange: null,
+			addListener: jest.fn(), // Deprecated
+			removeListener: jest.fn(), // Deprecated
+			addEventListener: jest.fn(),
+			removeEventListener: jest.fn(),
+			dispatchEvent: jest.fn(),
+		})),
+	});
+});

--- a/src/__tests__/components/holidayCard.test.jsx
+++ b/src/__tests__/components/holidayCard.test.jsx
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import { cleanup, render, screen, fireEvent } from '@testing-library/react';
+import HolidayCard from '../../components/card/holidayCard';
+import { formatDate } from '../../utils/formatDate';
+import { getCurrencySymbol } from '../../utils/currencySymbol';
+import { renderWithTheme } from '../test-utils';
+import mockData from '../../__mocks__/mock-data.json';
+
+const mockProps1 = mockData[0];
+
+describe('HolidayCard', () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	test('it renders the resort information correctly', () => {
+		renderWithTheme(<HolidayCard props={mockProps1} />);
+		expect(screen.getByText('Iberostar Grand Salome')).toBeDefined();
+		expect(screen.getByText('Costa Adeje, Tenerife')).toBeDefined();
+	});
+
+	test('it displays the correct number of adults, children, and infants', () => {
+		renderWithTheme(<HolidayCard props={mockProps1} />);
+		expect(screen.getByTestId('partySize').textContent).toString(
+			'2 Adults, 2 children & 1 infant'
+		);
+	});
+
+	test('it formats the date, length of stay, and departure airport correctly', () => {
+		renderWithTheme(<HolidayCard props={mockProps1} />);
+		const formattedDate = formatDate(
+			mockProps1.flightDetails.departureDate
+		);
+		expect(screen.getByTestId('resortStay').textContent).toString(
+			`${formattedDate} for 7 days`
+		);
+		expect(screen.getByTestId('departure').textContent).toString(
+			'departing from East Midlands'
+		);
+	});
+
+	test('it formats and displays the price with currency', () => {
+		renderWithTheme(<HolidayCard props={mockProps1} />);
+		const formattedPrice = `${getCurrencySymbol(
+			mockProps1.bookingDetails.price.currency
+		)}1,136.50`;
+		expect(screen.getByText(formattedPrice)).toBeDefined();
+	});
+
+	test('it toggles the accordion and changes button text on click', () => {
+		renderWithTheme(<HolidayCard props={mockProps1} />);
+		const accordionButton = screen.getByText('Read more about this hotel');
+
+		expect(screen.queryByText('Overview')).toBeNull();
+
+		fireEvent.click(accordionButton);
+		expect(screen.getByText('Overview')).toBeDefined();
+		expect(screen.getByText('Read less about this hotel')).toBeDefined();
+
+		fireEvent.click(accordionButton);
+		expect(screen.queryByText('Overview')).toBeNull();
+		expect(screen.getByText('Read more about this hotel')).toBeDefined();
+	});
+
+	test('it shows the correct overview text when expanded', () => {
+		renderWithTheme(<HolidayCard props={mockProps1} />);
+		const accordionButton = screen.getByText('Read more about this hotel');
+		fireEvent.click(accordionButton);
+
+		expect(
+			screen.getByText(
+				'The Iberostar Grand Salomehas an exceptional location in the south of Tenrife, overlooking the Atlantic Ocean. It is situated between the Golf del Sur and the Amarillo Golf Courses, and is an ideal hotel for families couples and groups who are looking for a holiday full of sport, sun and sea.'
+			)
+		).toBeDefined();
+	});
+});

--- a/src/__tests__/components/sortingMenu.test.jsx
+++ b/src/__tests__/components/sortingMenu.test.jsx
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { cleanup, screen, fireEvent } from '@testing-library/react';
+import { renderWithTheme } from '../test-utils';
+import SortingMenu from '../../components/menu/sortingMenu';
+
+describe('SortingMenu', () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	test('renders all sorting options', () => {
+		renderWithTheme(<SortingMenu onSortChange={vi.fn()} />);
+
+		expect(screen.getByTestId('sortAz').textContent).toString(
+			'sort alphabetically'
+		);
+		expect(screen.getByTestId('sortPrice').textContent).toString(
+			'sort by price'
+		);
+		expect(screen.getByTestId('sortRatings').textContent).toString(
+			'sort by star rating'
+		);
+	});
+
+	test('changes the sorting direction when a button is clicked', () => {
+		const onSortChange = vi.fn();
+		renderWithTheme(<SortingMenu onSortChange={onSortChange} />);
+
+		const alphabeticalButton = screen.getByTestId('sortAz');
+		fireEvent.click(alphabeticalButton);
+
+		expect(onSortChange).toHaveBeenCalledWith({
+			type: 'alphabetical',
+			direction: 'desc',
+		});
+	});
+
+	test('toggles the sorting direction on multiple clicks', () => {
+		const onSortChange = vi.fn();
+		renderWithTheme(<SortingMenu onSortChange={onSortChange} />);
+
+		const alphabeticalButton = screen.getByTestId('sortAz');
+
+		fireEvent.click(alphabeticalButton);
+		expect(onSortChange).toHaveBeenCalledWith({
+			type: 'alphabetical',
+			direction: 'desc',
+		});
+
+		fireEvent.click(alphabeticalButton);
+		expect(onSortChange).toHaveBeenCalledWith({
+			type: 'alphabetical',
+			direction: 'asc',
+		});
+	});
+
+	test('displays the correct icons based on sorting direction', () => {
+		renderWithTheme(<SortingMenu onSortChange={vi.fn()} />);
+
+		const alphabeticalButton = screen.getByTestId('sortAz');
+
+		expect(screen.getByTestId('FaSortAlphaDown')).toBeDefined();
+
+		fireEvent.click(alphabeticalButton);
+
+		expect(screen.getByTestId('FaSortAlphaUp')).toBeDefined();
+	});
+
+	test('calls onSortChange with correct parameters when clicking on price button', () => {
+		const onSortChange = vi.fn();
+		renderWithTheme(<SortingMenu onSortChange={onSortChange} />);
+
+		const priceButton = screen.getByTestId('sortPrice');
+
+		fireEvent.click(priceButton);
+		expect(onSortChange).toHaveBeenCalledWith({
+			type: 'price',
+			direction: 'desc',
+		});
+
+		fireEvent.click(priceButton);
+		expect(onSortChange).toHaveBeenCalledWith({
+			type: 'price',
+			direction: 'asc',
+		});
+	});
+
+	test('properly toggles between sort directions when clicking multiple buttons', () => {
+		const onSortChange = vi.fn();
+		renderWithTheme(<SortingMenu onSortChange={onSortChange} />);
+
+		const priceButton = screen.getByTestId('sortPrice');
+		const ratingButton = screen.getByTestId('sortRatings');
+
+		fireEvent.click(priceButton);
+		expect(onSortChange).toHaveBeenCalledWith({
+			type: 'price',
+			direction: 'desc',
+		});
+
+		fireEvent.click(ratingButton);
+		expect(onSortChange).toHaveBeenCalledWith({
+			type: 'rating',
+			direction: 'desc',
+		});
+
+		fireEvent.click(priceButton);
+		expect(onSortChange).toHaveBeenCalledWith({
+			type: 'price',
+			direction: 'asc',
+		});
+	});
+});

--- a/src/__tests__/pages/page.test.jsx
+++ b/src/__tests__/pages/page.test.jsx
@@ -1,16 +1,69 @@
 import Home from '../../app/page';
-import { afterEach, describe, expect, test } from 'vitest';
-import { cleanup } from '@testing-library/react';
-import { render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { cleanup, screen, waitFor } from '@testing-library/react';
+import { renderWithTheme } from '../test-utils';
+import { fetchData } from '../../utils/fetchData';
+import mockData from '../../__mocks__/mock-data.json';
+
+beforeEach(() => {
+	global.fetch = vi.fn();
+	vi.clearAllMocks();
+});
+
+afterEach(() => {
+	cleanup();
+});
 
 describe('Homepage', () => {
-	afterEach(() => {
-		cleanup();
+	test('it should load the homepage and render necessary components when data is fetched successfully', async () => {
+		vi.spyOn(global, 'fetch').mockImplementation(() =>
+			Promise.resolve({ ok: true, json: () => Promise.resolve(mockData) })
+		);
+
+		renderWithTheme(<Home />);
+
+		expect(screen.getByText('Loading resorts...')).toBeDefined();
+
+		await waitFor(() =>
+			expect(
+				screen.getAllByRole('button', { name: /sort/i })
+			).toHaveLength(3)
+		);
+
+		expect(screen.getAllByText('Book now')).toHaveLength(3);
+
+		expect(screen.getByText(/Created by Mariam H | 2024/)).toBeDefined();
 	});
 
-	test('it should load the homepage', async () => {
-		const result = render(<Home />);
-		const hello = result.getByText('Hello!');
-		expect(hello).toBeDefined();
+	test('it should show an error message when data fetching fails', async () => {
+		vi.spyOn(global, 'fetch').mockRejectedValueOnce(
+			new Error('Failed to fetch data')
+		);
+
+		renderWithTheme(<Home />);
+
+		expect(screen.getByText('Loading resorts...')).toBeDefined();
+
+		await waitFor(() =>
+			screen.getByText(/Error loading resorts: Failed to fetch data/)
+		);
+
+		expect(
+			screen.getByText(/Error loading resorts: Failed to fetch data/)
+		).toBeDefined();
+	});
+
+	test('it should render the loading spinner while data is being fetched', async () => {
+		vi.spyOn(global, 'fetch').mockImplementation(() =>
+			Promise.resolve({ ok: true, json: () => Promise.resolve(mockData) })
+		);
+
+		renderWithTheme(<Home />);
+
+		expect(screen.getByText('Loading resorts...')).toBeDefined();
+
+		await waitFor(() =>
+			expect(screen.queryByText('Loading resorts...')).toBeNull()
+		);
 	});
 });

--- a/src/__tests__/test-utils.jsx
+++ b/src/__tests__/test-utils.jsx
@@ -1,0 +1,8 @@
+import Provider from '../app/provider';
+import { render } from '@testing-library/react';
+import React from 'react';
+
+export const renderWithTheme = (ui) => {
+	const Wrapper = ({ children }) => <Provider>{children}</Provider>;
+	return render(ui, { wrapper: Wrapper });
+};

--- a/src/__tests__/utils/fetchData.test.js
+++ b/src/__tests__/utils/fetchData.test.js
@@ -1,0 +1,44 @@
+import { fetchData } from '../../utils/fetchData';
+import { beforeEach, afterEach, describe, expect, test, vi } from 'vitest';
+import mockData from '../../__mocks__/mock-data.json';
+
+beforeEach(() => {
+	global.fetch = vi.fn();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe('fetchResortData', () => {
+	test('should return data when the fetch is successful', async () => {
+		global.fetch.mockResolvedValueOnce({
+			ok: true,
+			json: async () => mockData,
+		});
+
+		const data = await fetchData();
+
+		expect(data).toEqual(mockData);
+		expect(global.fetch).toHaveBeenCalledOnce();
+	});
+
+	test('should throw an error if the fetch response is not ok', async () => {
+		global.fetch.mockResolvedValueOnce({
+			ok: false,
+			statusText: 'Not Found',
+		});
+
+		await expect(fetchData()).rejects.toThrowError(
+			'Failed to fetch resorts data'
+		);
+		expect(global.fetch).toHaveBeenCalledOnce();
+	});
+
+	test('should throw an error if there is a network error', async () => {
+		global.fetch.mockRejectedValueOnce(new Error('Network error'));
+
+		await expect(fetchData()).rejects.toThrowError('Network error');
+		expect(global.fetch).toHaveBeenCalledOnce();
+	});
+});

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -1,9 +1,94 @@
+'use client';
+import React, { useState, useEffect } from 'react';
+import HolidayCard from '../components/card/holidayCard';
 import styles from './page.module.css';
+import { Stack, VStack, Spinner, Text } from '@chakra-ui/react';
+import SortingMenu from '../components/menu/sortingMenu';
+import { fetchData } from '../utils/fetchData';
 
 export default function Home() {
+	const [resortData, setResortData] = useState([]);
+	const [sortedData, setSortedData] = useState([]);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState(null);
+
+	useEffect(() => {
+		const getResortData = async () => {
+			try {
+				const data = await fetchData();
+				setResortData(data);
+				setSortedData(data);
+			} catch (err) {
+				setError(err.message);
+			} finally {
+				setLoading(false);
+			}
+		};
+
+		getResortData();
+	}, []);
+
+	const handleSortChange = ({ type, direction }) => {
+		const sorted = [...resortData].sort((a, b) => {
+			if (type === 'alphabetical') {
+				return direction === 'asc'
+					? a.resort.name.localeCompare(b.resort.name)
+					: b.resort.name.localeCompare(a.resort.name);
+			}
+			if (type === 'price') {
+				return direction === 'asc'
+					? a.bookingDetails.price.amount -
+							b.bookingDetails.price.amount
+					: b.bookingDetails.price.amount -
+							a.bookingDetails.price.amount;
+			}
+			if (type === 'rating') {
+				return direction === 'asc'
+					? a.resort.starRating - b.resort.starRating
+					: b.resort.starRating - a.resort.starRating;
+			}
+		});
+		setSortedData(sorted);
+	};
+
+	if (loading) {
+		return (
+			<div className={styles.page}>
+				<main className={styles.main}>
+					<Stack direction='row' gap={20}>
+						<Spinner size='lg' />
+						<Text>Loading resorts...</Text>
+					</Stack>
+				</main>
+			</div>
+		);
+	}
+
+	if (error) {
+		return (
+			<div className={styles.page}>
+				<main className={styles.main}>
+					<Text color='red.500'>Error loading resorts: {error}</Text>
+				</main>
+			</div>
+		);
+	}
+
 	return (
 		<div className={styles.page}>
-			<main className={styles.main}>Hello!</main>
+			<main className={styles.main}>
+				<Stack direction='row' gap={20}>
+					<SortingMenu onSortChange={handleSortChange} />
+					<VStack gap={8} w='67%'>
+						{sortedData.map((vacation) => (
+							<HolidayCard
+								key={vacation.resort.id}
+								props={vacation}
+							/>
+						))}
+					</VStack>
+				</Stack>
+			</main>
 			<footer className={styles.footer}>
 				Created by Mariam H | 2024
 			</footer>

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -1,53 +1,24 @@
 .page {
-	display: grid;
-	grid-template-rows: 20px 1fr 20px;
 	align-items: center;
 	justify-items: center;
 	min-height: 100svh;
-	padding: 80px;
-	gap: 64px;
+	padding: 2.5rem;
 	background-image: url('/background.png');
 	background-attachment: fixed;
 	background-position: 50% 60%;
+	gap: 10rem;
 }
 
 .main {
 	display: flex;
-	flex-direction: column;
-	gap: 32px;
-	grid-row-start: 2;
+	flex-direction: row;
+	gap: 4rem;
 }
 
 .footer {
-	grid-row-start: 3;
 	display: flex;
-	gap: 24px;
+	margin-top: 4rem;
 	color: grey;
 }
 
-.footer a {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-}
-
-.footer img {
-	flex-shrink: 0;
-}
-
-@media (max-width: 600px) {
-	.page {
-		padding: 32px;
-		padding-bottom: 80px;
-	}
-
-	.main {
-		align-items: center;
-	}
-
-	.footer {
-		flex-wrap: wrap;
-		align-items: center;
-		justify-content: center;
-	}
-}
+/* If I had more time: Add screen sizings and reactivity to the page*/

--- a/src/components/card/holidayCard.jsx
+++ b/src/components/card/holidayCard.jsx
@@ -1,0 +1,136 @@
+'use client';
+
+import React, { useState } from 'react';
+import styles from './holidayCard.module.css';
+import { Button, Card, Image, Stack, Text } from '@chakra-ui/react';
+import { Rating } from '../ui/rating';
+import { formatDate } from '../../utils/formatDate';
+import { getCurrencySymbol } from '../../utils/currencySymbol';
+
+const HolidayCard = ({ props }) => {
+	const [isExpanded, setIsExpanded] = useState(false);
+
+	const resort = props?.resort;
+	const bookings = props?.bookingDetails;
+	const flight = props?.flightDetails;
+	const date = formatDate(flight?.departureDate);
+	const price = `${getCurrencySymbol(bookings?.price?.currency)}${Number(
+		bookings?.price?.amount
+	)
+		.toFixed(2)
+		.replace(/\B(?=(\d{3})+(?!\d))/g, ',')}`;
+
+	const toggleAccordion = () => setIsExpanded(!isExpanded);
+
+	return (
+		<Card.Root className={styles.container}>
+			<Card.Body className={styles.cardBody}>
+				<div className={styles.imageContainer}>
+					<Image src={resort?.image?.url} alt={resort?.name} />
+					<div
+						className={styles.accordionButton}
+						onClick={toggleAccordion}
+					>
+						<Text textStyle='xs'>
+							{isExpanded ? 'Read less' : 'Read more'} about this
+							hotel
+						</Text>
+						<span className={styles.accordionIcon}>
+							{isExpanded ? '▲' : '▼'}
+						</span>
+					</div>
+				</div>
+
+				<div className={styles.details}>
+					<div className={styles.title}>
+						<Card.Title>{resort.name}</Card.Title>
+						<Card.Description>
+							{resort?.regionName}, {resort?.countryName}
+						</Card.Description>
+					</div>
+
+					<Rating
+						defaultValue={resort?.starRating}
+						size='sm'
+						readOnly
+						colorPalette='yellow'
+					/>
+
+					<Stack gap={1}>
+						<Text textStyle='xs' data-testid='partySize'>
+							{bookings?.party?.adults && (
+								<>
+									<strong>
+										{bookings.party.adults}&nbsp;
+									</strong>
+									{bookings.party.adults > 1
+										? 'Adults'
+										: 'Adult'}
+								</>
+							)}
+
+							{bookings?.party?.children && (
+								<>
+									{bookings.party.adults ? ', ' : ''}
+									<strong>
+										{bookings.party.children}&nbsp;
+									</strong>
+									{bookings.party.children > 1
+										? 'children'
+										: 'child'}
+								</>
+							)}
+
+							{bookings?.party?.infants && (
+								<>
+									{bookings.party.adults ||
+									bookings.party.children
+										? ' & '
+										: ''}
+									<strong>
+										{bookings.party.infants}&nbsp;
+									</strong>
+									{bookings.party.infants > 1
+										? 'infants'
+										: 'infant'}
+								</>
+							)}
+						</Text>
+
+						<Text textStyle='xs' data-testid='resortStay'>
+							<strong>{date}</strong> for{' '}
+							<strong>{bookings?.lengthOfStay}</strong> days
+						</Text>
+
+						<Text textStyle='xs' data-testid='departure'>
+							departing from{' '}
+							<strong>{flight.departureAirport}</strong>
+						</Text>
+					</Stack>
+
+					<Button>
+						<Text textStyle='xs'>Book now</Text>
+						<Text textStyle='2xl' className={styles.buttonText}>
+							{price}
+						</Text>
+					</Button>
+				</div>
+			</Card.Body>
+
+			{isExpanded && (
+				<Card.Footer className={styles.accordionContent}>
+					<Card.Footer className={styles.footer}>
+						<Stack gap={3}>
+							<Card.Title className={styles.footerTitle}>
+								Overview
+							</Card.Title>
+							<Text textStyle='sm'>{resort.overview}</Text>
+						</Stack>
+					</Card.Footer>
+				</Card.Footer>
+			)}
+		</Card.Root>
+	);
+};
+
+export default HolidayCard;

--- a/src/components/card/holidayCard.module.css
+++ b/src/components/card/holidayCard.module.css
@@ -1,0 +1,87 @@
+.container {
+	border: none;
+	border-radius: 0rem;
+	background: white;
+	width: 50rem;
+	color: black;
+}
+
+.container img {
+	object-fit: cover;
+	width: 100%;
+	border-radius: 0;
+}
+
+.cardBody {
+	display: flex;
+	flex-direction: row;
+	width: 100%;
+}
+
+.details {
+	padding: 1rem;
+	display: flex;
+	flex-direction: column;
+	gap: 0.8rem;
+	margin: 0.25rem;
+	color: black;
+}
+
+.title {
+	color: var(--dark-blue);
+}
+
+.details button {
+	display: flex;
+	flex-direction: column;
+	gap: 0;
+	padding: 0.5rem;
+	width: 16rem;
+	height: 4rem;
+	background: var(--yellow);
+	border: none;
+	font-weight: 800;
+	color: var(--dark-blue);
+}
+
+.details button .buttonText {
+	letter-spacing: 0.02rem;
+}
+
+.footer {
+	padding: 1rem;
+}
+
+.footerTitle {
+	color: var(--dark-blue);
+}
+
+.imageContainer {
+	position: relative;
+	width: 100%;
+}
+
+.accordionButton {
+	position: absolute;
+	bottom: 0px;
+	left: 0px;
+	cursor: pointer;
+	background-color: white;
+	padding: 0.5rem 0.5rem;
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	font-weight: bold;
+	color: var(--dark-blue);
+	transition: background-color 0.2s;
+	width: 40%;
+}
+
+.accordionIcon {
+	font-size: 1rem;
+	transition: transform 0.2s;
+}
+
+.accordionContent {
+	border-bottom: solid 1px var(--grey);
+}

--- a/src/components/menu/sortingMenu.jsx
+++ b/src/components/menu/sortingMenu.jsx
@@ -1,0 +1,121 @@
+import React, { useState } from 'react';
+import { Button, VStack, HStack, Text } from '@chakra-ui/react';
+import styles from './sortingMenu.module.css';
+import {
+	FaSortAlphaDown,
+	FaSortAlphaUp,
+	FaSortAmountDown,
+	FaSortAmountUp,
+	FaStar,
+	FaStarHalfAlt,
+} from 'react-icons/fa';
+
+const SortingMenu = ({ onSortChange }) => {
+	// Before, it was only implemented as: useState({ type: 'alphabetical', direction: 'asc' });
+	// however, I wanted to maintain state across all 3 types to keep consistency in the UI for the end user
+	// but also separate the logic out. This took a bit of time to think on what the best structure was to
+	// use this logic.
+	const [sortDirections, setSortDirections] = useState({
+		alphabetical: 'asc',
+		price: 'asc',
+		rating: 'asc',
+	});
+
+	// Leveraging state to ensure styling shows which one is 'active'.
+	const [selectedOption, setSelectedOption] = useState(null);
+
+	const handleSortChange = (type) => {
+		const newDirection = sortDirections[type] === 'asc' ? 'desc' : 'asc';
+
+		setSortDirections((prevState) => ({
+			...prevState,
+			[type]: newDirection,
+		}));
+
+		setSelectedOption(type);
+
+		onSortChange({ type, direction: newDirection });
+	};
+
+	// From a UI/UX Perspective, I would like instant feedback on knowing whether something is ASC/DSC and which one
+	// this may make the component a tiny bit bulkier (kudos of react-icons too), but balancing performance with a good
+	// user experience is worth it!
+	const getSortIcon = (type) => {
+		if (type === 'alphabetical')
+			return sortDirections[type] === 'asc' ? (
+				// In the interest of time I added data test ids for unit tests, with more time I would've focused
+				// on reading docs to pull out the exact properties I can use of the element to test icon switches
+				<FaSortAlphaDown data-testid='FaSortAlphaDown' />
+			) : (
+				<FaSortAlphaUp data-testid='FaSortAlphaUp' />
+			);
+		if (type === 'price')
+			return sortDirections[type] === 'asc' ? (
+				<FaSortAmountDown data-testid='FaSortAmountDown' />
+			) : (
+				<FaSortAmountUp data-testid='FaSortAmountUp' />
+			);
+		if (type === 'rating')
+			return sortDirections[type] === 'asc' ? (
+				<FaStarHalfAlt data-testid='FaStarHalfAlt' />
+			) : (
+				<FaStar data-testid='FaStar' />
+			);
+	};
+
+	return (
+		// I like a mix of leveraging a component library (3rd party or self-built) and classic elements to ensure
+		// the components stay a concise and reasonable length and reducing the need for styling across every element.
+		<VStack className={styles.menu} gap={0.5}>
+			{/* AZ */}
+			<Button
+				onClick={() => handleSortChange('alphabetical')}
+				className={`${styles.option} ${
+					selectedOption === 'alphabetical' ? styles.selected : ''
+				}`}
+				data-testid='sortAz'
+			>
+				<HStack>
+					<Text>
+						sort <strong>alphabetically</strong>
+					</Text>
+					{getSortIcon('alphabetical')}
+				</HStack>
+			</Button>
+
+			{/* Price */}
+			<Button
+				onClick={() => handleSortChange('price')}
+				className={`${styles.option} ${
+					selectedOption === 'price' ? styles.selected : ''
+				}`}
+				data-testid='sortPrice'
+			>
+				<HStack>
+					<Text>
+						sort by <strong>price</strong>
+					</Text>
+					{getSortIcon('price')}
+				</HStack>
+			</Button>
+
+			{/* Stars */}
+			<Button
+				onClick={() => handleSortChange('rating')}
+				className={`${styles.option} ${
+					selectedOption === 'rating' ? styles.selected : ''
+				}`}
+				data-testid='sortRatings'
+			>
+				<HStack>
+					<Text>
+						sort by <strong>star rating</strong>
+					</Text>
+					{getSortIcon('rating')}
+				</HStack>
+			</Button>
+		</VStack>
+	);
+};
+
+export default SortingMenu;

--- a/src/components/menu/sortingMenu.module.css
+++ b/src/components/menu/sortingMenu.module.css
@@ -1,0 +1,45 @@
+.menu {
+	display: flex;
+	flex-direction: column;
+	width: 90%;
+	height: 20%;
+	alignitems: 'stretch';
+	gap: 0;
+}
+
+.option {
+	margin: 0;
+	gap: 0;
+	padding: 0.75rem 1rem;
+	cursor: pointer;
+	font-size: 1rem;
+	border-radius: 0;
+	width: 100%;
+	height: 3rem;
+	color: var(--dark-blue);
+	background: white;
+	transition: background-color 0.3s, color 0.3s;
+}
+
+.option div {
+	width: 100%;
+	justify-content: space-between;
+}
+
+.option svg {
+	margin-left: 0.5rem;
+	color: var(--grey);
+}
+
+.selected {
+	background-color: var(--dark-blue);
+	color: white;
+}
+
+.selected svg {
+	color: white;
+}
+
+.option:hover {
+	background-color: var(--grey);
+}

--- a/src/components/ui/rating.jsx
+++ b/src/components/ui/rating.jsx
@@ -1,0 +1,19 @@
+import { RatingGroup } from '@chakra-ui/react'
+import { forwardRef } from 'react'
+
+export const Rating = forwardRef(function Rating(props, ref) {
+  const { icon, count = 5, label, ...rest } = props
+  return (
+    <RatingGroup.Root ref={ref} count={count} {...rest}>
+      {label && <RatingGroup.Label>{label}</RatingGroup.Label>}
+      <RatingGroup.HiddenInput />
+      <RatingGroup.Control>
+        {Array.from({ length: count }).map((_, index) => (
+          <RatingGroup.Item key={index} index={index + 1}>
+            <RatingGroup.ItemIndicator icon={icon} />
+          </RatingGroup.Item>
+        ))}
+      </RatingGroup.Control>
+    </RatingGroup.Root>
+  )
+})

--- a/src/utils/currencySymbol.js
+++ b/src/utils/currencySymbol.js
@@ -1,0 +1,12 @@
+export function getCurrencySymbol(currencyCode) {
+	switch (currencyCode.toUpperCase()) {
+		case 'GBP':
+			return '£';
+		case 'EUR':
+			return '€';
+		case 'USD':
+			return '$';
+		default:
+			return ' '; // Default message for unsupported currencies
+	}
+}

--- a/src/utils/fetchData.js
+++ b/src/utils/fetchData.js
@@ -1,0 +1,14 @@
+export const fetchData = async () => {
+	try {
+		const response = await fetch(
+			'https://static.onthebeach.co.uk/fe-code-test/data.json'
+		);
+		if (!response.ok) {
+			throw new Error('Failed to fetch resorts data');
+		}
+		const data = await response.json();
+		return data;
+	} catch (error) {
+		throw new Error(error.message);
+	}
+};

--- a/src/utils/formatDate.js
+++ b/src/utils/formatDate.js
@@ -1,0 +1,24 @@
+export function formatDate(dateString) {
+	const date = new Date(dateString);
+
+	const day = date.getUTCDate();
+
+	const getOrdinalSuffix = (day) => {
+		if (day > 3 && day < 21) return 'th';
+		switch (day % 10) {
+			case 1:
+				return 'st';
+			case 2:
+				return 'nd';
+			case 3:
+				return 'rd';
+			default:
+				return 'th';
+		}
+	};
+
+	const year = date.getUTCFullYear();
+	const month = date.toLocaleString('en-GB', { month: 'long' });
+
+	return `${day}${getOrdinalSuffix(day)} ${month} ${year}`;
+}

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -12,5 +12,6 @@ export default defineConfig({
 		},
 		environment: 'jsdom',
 		globals: true,
+		setupFiles: ['./vitest.setup.js'],
 	},
 });

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -1,0 +1,30 @@
+import { vitest, beforeEach } from 'vitest';
+
+beforeEach(() => {
+	Object.defineProperty(window, 'matchMedia', {
+		writable: true,
+		value: vitest.fn().mockImplementation((query) => ({
+			matches: false,
+			media: query,
+			onchange: null,
+			addListener: vitest.fn(), // Deprecated
+			removeListener: vitest.fn(), // Deprecated
+			addEventListener: vitest.fn(),
+			removeEventListener: vitest.fn(),
+			dispatchEvent: vitest.fn(),
+		})),
+	});
+});
+
+// JSDOM has had issues with parsing CSS Stylesheets, this does not affect the quality of the component
+// testing, but if more time was available - I would've addressed this error to ensure we can also test
+// the classes, if required and discussed together by the team in 3As style.
+const originalConsoleError = console.error;
+console.error = function (...data) {
+	if (
+		typeof data[0]?.toString === 'function' &&
+		data[0].toString().includes('Error: Could not parse CSS stylesheet')
+	)
+		return;
+	originalConsoleError(...data);
+};


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

This PR adds the following features to the codebase:
- The resort card to showcase vacation details. This card displays the resort details, stay duration, an option to book, and a drop down menu.
- A sorting menu. This menu allows the user to sort stuff by ascending and descending order for price, ratings, and by name. 

As part of these two components, a set of utility functions have been created to assist in the following:
- Formatting of dates
- Formatting of currency and price
- Fetching of resort data with error handling

As part of this feature, a new component library has been added to the codebase, namely [ChakraUI](https://www.chakra-ui.com/). Although a minimal amount of components are used, Chakra has been used over MUI due as it's less bulky. 

This feature also introduces further fitest unit testing for all components and functions. 

Please note: pictures have been attached to showcase the various expected functionalities.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit tests

**Test Configuration**:
* Firmware version: Sequoia 15.1
* Hardware: Mac M2 Pro 
* Toolchain: N/A
* SDK: N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

